### PR TITLE
Add OSGi metadata to jnr-enxio.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,41 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <configuration>
+          <instructions>
+            <_nouses>true</_nouses>
+            <Import-Package>*,jnr.ffi.mapper,jnr.ffi.provider.converters,com.kenai.jffi</Import-Package>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
 
     <profile>


### PR DESCRIPTION
Use maven-bundle-plugin to generate OSGi metadata and include the
manifest using maven-jar-plugin.

This change only adds additional entries to the MANIFEST.MF shipped in the final jar artifact. The attributes would not affect current consumers of this artifact.