### PR TITLE
replace hardcoded C library name with function that returns platform

### DIFF
--- a/src/main/java/jnr/enxio/channels/Native.java
+++ b/src/main/java/jnr/enxio/channels/Native.java
@@ -27,6 +27,7 @@ import jnr.ffi.annotations.Out;
 import jnr.ffi.annotations.Transient;
 import jnr.ffi.types.size_t;
 import jnr.ffi.types.ssize_t;
+import jnr.ffi.Platform;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -61,7 +62,7 @@ final class Native {
     }
 
     private static final class SingletonHolder {
-        static final LibC libc = LibraryLoader.create(LibC.class).load("c");
+        static final LibC libc = LibraryLoader.create(LibC.class).load(Platform.getNativePlatform().getStandardCLibraryName());
         static final jnr.ffi.Runtime runtime = Runtime.getRuntime(libc);
     }
 

--- a/src/test/java/jnr/enxio/example/TCPServer.java
+++ b/src/test/java/jnr/enxio/example/TCPServer.java
@@ -42,7 +42,7 @@ import java.nio.channels.Selector;
 public class TCPServer {
     static final String[] libnames = Platform.getNativePlatform().getOS() == Platform.OS.SOLARIS
                         ? new String[] { "socket", "nsl", "c" }
-                        : new String[] { "c" };
+                        : new String[] { Platform.getNativePlatform().getStandardCLibraryName() };
     static final LibC libc = Library.loadLibrary(LibC.class, libnames);
     static final jnr.ffi.Runtime runtime = jnr.ffi.Runtime.getSystemRuntime();
 


### PR DESCRIPTION
Modified SingletonHolder to use a function call that returns platform specific C library name instead of the hardcoded string to address issue https://github.com/jnr/jnr-enxio/issues/12#issuecomment-193826434