### PR TITLE
Throw an IOException if native close() fails.

### DIFF
--- a/src/main/java/jnr/enxio/channels/Native.java
+++ b/src/main/java/jnr/enxio/channels/Native.java
@@ -82,7 +82,7 @@ final class Native {
 
         if (rc < 0) {
             String message = String.format("Error closing fd %d: %s", fd, getLastErrorString());
-            throw new IOException(message);
+            throw new NativeException(message, getLastError());
         } else {
             return rc;
         }

--- a/src/main/java/jnr/enxio/channels/Native.java
+++ b/src/main/java/jnr/enxio/channels/Native.java
@@ -74,13 +74,18 @@ final class Native {
         return SingletonHolder.runtime;
     }
 
-    public static int close(int fd) {
+    public static int close(int fd) throws IOException {
         int rc;
         do {
             rc = libc().close(fd);
         } while (rc < 0 && Errno.EINTR.equals(getLastError()));
 
-        return rc;
+        if (rc < 0) {
+            String message = String.format("Error closing fd %d: %s", fd, getLastErrorString());
+            throw new IOException(message);
+        } else {
+            return rc;
+        }
     }
 
     public static int read(int fd, ByteBuffer dst) throws IOException {

--- a/src/main/java/jnr/enxio/channels/NativeException.java
+++ b/src/main/java/jnr/enxio/channels/NativeException.java
@@ -1,0 +1,18 @@
+package jnr.enxio.channels;
+
+import jnr.constants.platform.Errno;
+
+import java.io.IOException;
+
+public class NativeException extends IOException {
+    private final Errno errno;
+
+    public NativeException(String message, Errno errno) {
+        super(message);
+        this.errno = errno;
+    }
+
+    public Errno getErrno() {
+        return errno;
+    }
+}

--- a/src/test/java/jnr/enxio/channels/NativeTest.java
+++ b/src/test/java/jnr/enxio/channels/NativeTest.java
@@ -6,7 +6,6 @@ import org.junit.rules.ExpectedException;
 
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.lang.reflect.Field;
 
 public class NativeTest {
@@ -21,7 +20,7 @@ public class NativeTest {
         fdField.setAccessible(true);
         int fd = (int)(Integer)fdField.get(descriptor);
         Native.close(fd);
-        expectedEx.expect(IOException.class);
+        expectedEx.expect(NativeException.class);
         Native.close(fd);
     }
 }

--- a/src/test/java/jnr/enxio/channels/NativeTest.java
+++ b/src/test/java/jnr/enxio/channels/NativeTest.java
@@ -1,0 +1,27 @@
+package jnr.enxio.channels;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+public class NativeTest {
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Test
+    public void closeThrowsOnNativeError() throws Exception {
+        FileOutputStream fos = new FileOutputStream("/dev/null");
+        FileDescriptor descriptor = fos.getFD();
+        Field fdField = descriptor.getClass().getDeclaredField("fd");
+        fdField.setAccessible(true);
+        int fd = (int)(Integer)fdField.get(descriptor);
+        Native.close(fd);
+        expectedEx.expect(IOException.class);
+        Native.close(fd);
+    }
+}


### PR DESCRIPTION
close() failure may happen in case of a double close on same fd, which speaks of logical errors in code.
