### PR TITLE
Handle EAGAIN/EWOULDBLOCK in a special way

### DIFF
--- a/src/main/java/jnr/enxio/channels/NativeSocketChannel.java
+++ b/src/main/java/jnr/enxio/channels/NativeSocketChannel.java
@@ -88,7 +88,13 @@ public class NativeSocketChannel extends AbstractSelectableChannel
     public int write(ByteBuffer src) throws IOException {
         int n = Native.write(fd, src);
         if (n < 0) {
-            throw new IOException(Native.getLastErrorString());
+            switch (Native.getLastError()) {
+                case EAGAIN:
+                case EWOULDBLOCK:
+                    return 0;
+            default:
+                throw new IOException(Native.getLastErrorString());
+            }
         }
 
         return n;


### PR DESCRIPTION
Return 0 if write failed with EAGAIN/EWOULDBLOCK error. Looks a little
bit tricky for me, but made consistent with read operation.