### PR TITLE
Fix the examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ jnr-enxio
 
 Native I/O access for java
 
-Check out the [examples](https://github.com/jnr/jnr-unixsocket/tree/master/src/main/test/jnr/enxio/example) for more information.
+Check out the [examples](https://github.com/jnr/jnr-enxio/tree/master/src/test/java/jnr/enxio/example) for more information.


### PR DESCRIPTION
The examples link points to the wrong project.