### PR TITLE
Fix the `keys` method for PollSelector

### DIFF
--- a/src/main/java/jnr/enxio/channels/PollSelector.java
+++ b/src/main/java/jnr/enxio/channels/PollSelector.java
@@ -63,7 +63,6 @@ class PollSelector extends java.nio.channels.spi.AbstractSelector {
         putPollFD(0, pipefd[0]);
         putPollEvents(0, POLLIN);
         nfds = 1;
-        keyArray = new PollSelectionKey[1];
     }
     
     private void putPollFD(int idx, int fd) {


### PR DESCRIPTION
The current implementation of the `keys` method is broken, because it can return null values in the resulted set. For instance, `PollSelector` starts with `keyArray` of  the size of 1. The returned set then will always have a null value in the set. External systems that call this method don't expect that the set will contain null values and don't check for it. For instance, Jetty doesn't do that.

A better implementation of the `keys` method is to just delegate a call to the `keys` map, managed by `PollSelector`. It doesn't create a new set, doesn't create null values and it's more simple.