### PR TITLE
Move abstract implementations from jnr-unixsocket

### DIFF
--- a/src/main/java/jnr/enxio/channels/AbstractNativeDatagramChannel.java
+++ b/src/main/java/jnr/enxio/channels/AbstractNativeDatagramChannel.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.enxio.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.spi.SelectorProvider;
+
+public abstract class AbstractNativeDatagramChannel extends DatagramChannel
+    implements ByteChannel, NativeSelectableChannel {
+
+    private final Common common;
+
+    public AbstractNativeDatagramChannel(int fd) {
+        this(NativeSelectorProvider.getInstance(), fd);
+    }
+
+    AbstractNativeDatagramChannel(SelectorProvider provider, int fd) {
+        super(provider);
+        common = new Common(fd);
+    }
+
+    public void setFD(int fd) {
+        common.setFD(fd);
+    }
+
+    public final int getFD() {
+        return common.getFD();
+    }
+
+    @Override
+    protected void implCloseSelectableChannel() throws IOException {
+        Native.close(common.getFD());
+    }
+
+    @Override
+    protected void implConfigureBlocking(boolean block) throws IOException {
+        Native.setBlocking(common.getFD(), block);
+    }
+
+    public int read(ByteBuffer dst) throws IOException {
+        return common.read(dst);
+    }
+
+    @Override
+    public long read(ByteBuffer[] dsts, int offset,
+            int length) throws IOException {
+        return common.read(dsts, offset, length);
+    }
+
+    public int write(ByteBuffer src) throws IOException {
+        return common.write(src);
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset,
+            int length) throws IOException {
+        return common.write(srcs, offset, length);
+    }
+
+}

--- a/src/main/java/jnr/enxio/channels/Common.java
+++ b/src/main/java/jnr/enxio/channels/Common.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2016 Fritz Elfert
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.enxio.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import jnr.constants.platform.Errno;
+
+/**
+ * Helper class, providing common methods.
+ */
+final class Common {
+
+    private int _fd = -1;
+
+    Common(int fd) {
+        _fd = fd;
+    }
+
+    void setFD(int fd) {
+        _fd = fd;
+    }
+
+    int getFD() {
+        return _fd;
+    }
+
+    int read(ByteBuffer dst) throws IOException {
+        int n = Native.read(_fd, dst);
+        switch (n) {
+            case 0:
+                return -1;
+
+            case -1:
+                switch (Native.getLastError()) {
+                    case EAGAIN:
+                    case EWOULDBLOCK:
+                        return 0;
+
+                    default:
+                        throw new IOException(Native.getLastErrorString());
+                }
+
+            default:
+                return n;
+        }
+    }
+
+    long read(ByteBuffer[] dsts, int offset, int length)
+        throws IOException {
+        long total = 0;
+
+        for (int i = 0; i < length; i++) {
+            ByteBuffer dst = dsts[offset + i];
+            long read = read(dst);
+            if (read == -1) {
+                return read;
+            }
+            total += read;
+        }
+
+        return total;
+    }
+
+    int write(ByteBuffer src) throws IOException {
+        int n = Native.write(_fd, src);
+        if (n < 0) {
+            switch (Native.getLastError()) {
+                case EAGAIN:
+                case EWOULDBLOCK:
+                    return 0;
+            default:
+                throw new IOException(Native.getLastErrorString());
+            }
+        }
+
+        return n;
+    }
+
+    long write(ByteBuffer[] srcs, int offset, int length)
+        throws IOException {
+
+        long result = 0;
+        int index = 0;
+
+        for (index = offset; index < length; index++) {
+            result += write(srcs[index]);
+        }
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
Move enxio related code recently added [here](https://github.com/jnr/jnr-unixsocket/pull/35) in order to reduce code duplication which can lead to reappearing errors like [this one](https://github.com/jnr/jnr-unixsocket/pull/38). 

At the moment there are still a lot of duplicated code, but I'm not sure how to properly fix it without API breakage, because `NativeSocket` extends `AbstractSelectableChannel`, while `AbstractNativeSocket` extends `SocketChannel`. @headius @enebo any ideas?

P.S. Is java6 still supported?