### PR TITLE
Always clear out descriptor metadata on registration

### DIFF
--- a/src/main/java/jnr/enxio/channels/KQSelector.java
+++ b/src/main/java/jnr/enxio/channels/KQSelector.java
@@ -107,11 +107,8 @@ class KQSelector extends java.nio.channels.spi.AbstractSelector {
     protected SelectionKey register(AbstractSelectableChannel ch, int ops, Object att) {
         KQSelectionKey k = new KQSelectionKey(this, (NativeSelectableChannel) ch, ops);
         synchronized (regLock) {
-            Descriptor d = descriptors.get(k.getFD());
-            if (d == null) {
-                d = new Descriptor(k.getFD());
-                descriptors.put(k.getFD(), d);
-            }
+            Descriptor d = new Descriptor(k.getFD());
+            descriptors.put(k.getFD(), d);
             d.keys.add(k);
             handleChangedKey(d);
         }


### PR DESCRIPTION
When registering on a channel, we should always reset the descriptor to its initial state. It is quite possible for a file descriptor to be re-used. In such scenarios, without this change, events may not fire. I observed this situation exactly when using jnr-unixsocket. I cancelled a key for OP_ACCEPT and closed the channel. On quickly opening a new channel and registering for OP_ACCEPT, the OS returned the same file descriptor as before. As the same descriptor metadata was used, I did not observe OP_ACCEPT events.

The changes here have been tested locally on my code base and observed to work correctly.

Fixes #27 