### PR TITLE
Selector Provider for file IO for macosx

### DIFF
--- a/src/main/java/jnr/enxio/channels/NativeDeviceChannel.java
+++ b/src/main/java/jnr/enxio/channels/NativeDeviceChannel.java
@@ -30,16 +30,27 @@ public class NativeDeviceChannel extends AbstractSelectableChannel implements By
 
     private final int fd;
     private final int validOps;
+    private final boolean isFile;
 
     public NativeDeviceChannel(int fd) {
-        this(NativeSelectorProvider.getInstance(), fd, SelectionKey.OP_READ | SelectionKey.OP_WRITE);
+        this(fd, false);
     }
-    public NativeDeviceChannel(SelectorProvider provider, int fd, int ops) {
+
+    public NativeDeviceChannel(int fd, boolean isFile) {
+        this(selectorProvider(isFile), fd, SelectionKey.OP_READ | SelectionKey.OP_WRITE, isFile);
+    }
+
+    public NativeDeviceChannel(SelectorProvider provider, int fd, int ops, boolean isFile) {
         super(provider);
         this.fd = fd;
         this.validOps = ops;
+        this.isFile = isFile;
     }
-    
+
+    private static SelectorProvider selectorProvider(boolean isFile) {
+        return (isFile) ? NativeFileSelectorProvider.getInstance() : NativeSelectorProvider.getInstance();
+    }
+
     @Override
     protected void implCloseSelectableChannel() throws IOException {
         int n = Native.close(fd);

--- a/src/main/java/jnr/enxio/channels/NativeFileSelectorProvider.java
+++ b/src/main/java/jnr/enxio/channels/NativeFileSelectorProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2008 Wayne Meissner
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.enxio.channels;
+
+import jnr.ffi.Platform;
+
+import java.io.IOException;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.Pipe;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.AbstractSelector;
+import java.nio.channels.spi.SelectorProvider;
+
+
+public final class NativeFileSelectorProvider extends SelectorProvider {
+    private static final class SingletonHolder {
+        static NativeFileSelectorProvider INSTANCE = new NativeFileSelectorProvider();
+    }
+
+    public static final SelectorProvider getInstance() {
+        return SingletonHolder.INSTANCE;
+    }
+
+    @Override
+    public DatagramChannel openDatagramChannel() throws IOException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public DatagramChannel openDatagramChannel(java.net.ProtocolFamily family) throws IOException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Pipe openPipe() throws IOException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public AbstractSelector openSelector() throws IOException {
+        return new PollSelector(this);
+    }
+
+    @Override
+    public ServerSocketChannel openServerSocketChannel() throws IOException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public SocketChannel openSocketChannel() throws IOException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+}


### PR DESCRIPTION
This PR is a prerequisite for https://github.com/jruby/jruby/issues/5287.

To read files, we want to use epoll selector instead of kqueue selector on macosx.

On FreeBSD platform, [kqueue](https://www.freebsd.org/cgi/man.cgi?query=kqueue) system call can be used to do asynchronous IO. But it is not designed to read files. EOF is not supported for _vnode_ filter. Problem was raised on the [mailing list](https://lists.freebsd.org/pipermail/freebsd-hackers/2003-November/004056.html).

 _kevent_ system call would block infinitely when there are no bytes left to read in the file descriptor. You need to explicitly exit event loop after reading the last bytes, as in [this example](https://gist.github.com/alexis779/3eac21f72ba2242996e98576c7cbde97#file-read_kqueue-c-L50-L53). Otherwise your call blocks indefinitely, as in jruby `IO#sysread` call on macosx. See [thread dump](https://gist.github.com/alexis779/b2eae94b3a90f9758e58499dbfeebf2f).
