### PR TITLE
Fixes an NPE

### DIFF
--- a/src/main/java/jnr/enxio/channels/KQSelector.java
+++ b/src/main/java/jnr/enxio/channels/KQSelector.java
@@ -214,13 +214,13 @@ class KQSelector extends java.nio.channels.spi.AbstractSelector {
             synchronized (regLock) {
                 for (SelectionKey k : cancelled) {
                     KQSelectionKey kqs = (KQSelectionKey) k;
-                    Descriptor d = descriptors.get(kqs.getFD());
                     deregister(kqs);
                     synchronized (selected) {
                         selected.remove(kqs);
                     }
-                    d.keys.remove(kqs);
-                    if (d.keys.isEmpty()) {
+                    Descriptor d = descriptors.get(kqs.getFD());
+                    if (d != null) d.keys.remove(kqs);
+                    if (d == null || d.keys.isEmpty()) {
                         io.put(changebuf, nchanged++, kqs.getFD(), EVFILT_READ, EV_DELETE);
                         io.put(changebuf, nchanged++, kqs.getFD(), EVFILT_WRITE, EV_DELETE);
                         descriptors.remove(kqs.getFD());


### PR DESCRIPTION
I had noticed an NPE under some, unknown circumstance. Here's the relevant stack trace:

```
Exception in thread "unix-domain-socket-io" java.lang.NullPointerException
	at jnr.enxio.channels.KQSelector$Descriptor.access$000(KQSelector.java:75)
	at jnr.enxio.channels.KQSelector.handleCancelledKeys(KQSelector.java:222)
	at jnr.enxio.channels.KQSelector.poll(KQSelector.java:150)
	at jnr.enxio.channels.KQSelector.select(KQSelector.java:145)
```

This should fix that.