### PR TITLE
Add basic Windows LibC support via MSVCRT

### DIFF
--- a/src/main/java/jnr/enxio/channels/WinLibCAdapter.java
+++ b/src/main/java/jnr/enxio/channels/WinLibCAdapter.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.enxio.channels;
+
+import java.nio.ByteBuffer;
+
+import jnr.enxio.channels.Native.LibC;
+import jnr.enxio.channels.Native.Timespec;
+import jnr.ffi.Pointer;
+import jnr.ffi.Runtime;
+import jnr.ffi.annotations.IgnoreError;
+import jnr.ffi.annotations.In;
+import jnr.ffi.annotations.Out;
+import jnr.ffi.provider.LoadedLibrary;
+import jnr.ffi.types.size_t;
+import jnr.ffi.types.ssize_t;
+
+/**
+ * MSVCRT.DLL only supports some LibC functions, but the symbols are different.
+ * This adapter maps the MSVCRT.DLL names to standard LibC names
+ */
+public final class WinLibCAdapter implements LibC, LoadedLibrary {
+
+    public static interface LibMSVCRT {
+
+        public int _close(int fd);
+        public @ssize_t int _read(int fd, @Out ByteBuffer data, @size_t long size);
+        public @ssize_t int _read(int fd, @Out byte[] data, @size_t long size);
+        public @ssize_t int _write(int fd, @In ByteBuffer data, @size_t long size);
+        public @ssize_t int _write(int fd, @In byte[] data, @size_t long size);
+        public int _pipe(@Out int[] fds);
+
+        @IgnoreError String _strerror(int error);
+
+        // These functions don't exist:
+
+        //public int shutdown(int s, int how);
+        //public int fcntl(int fd, int cmd, int data);
+        //public int poll(@In @Out ByteBuffer pfds, int nfds, int timeout);
+        //public int poll(@In @Out Pointer pfds, int nfds, int timeout);
+        //public int kqueue();
+        //public int kevent(int kq, @In ByteBuffer changebuf, int nchanges,
+        //                  @Out ByteBuffer eventbuf, int nevents,
+        //                  @In @Transient Timespec timeout);
+        //public int kevent(int kq,
+        //                  @In Pointer changebuf, int nchanges,
+        //                  @Out Pointer eventbuf, int nevents,
+        //                  @In @Transient Timespec timeout);
+    }
+
+    private LibMSVCRT win;
+    public WinLibCAdapter(LibMSVCRT winlibc) { this.win = winlibc; }
+
+    @Override public int close(int fd) { return win._close(fd); }
+    @Override public int read(int fd, ByteBuffer data, long size) { return win._read(fd, data, size); }
+    @Override public int read(int fd, byte[] data, long size) { return win._read(fd, data, size); }
+    @Override public int write(int fd, ByteBuffer data, long size) { return win._write(fd, data, size); }
+    @Override public int write(int fd, byte[] data, long size) { return win._write(fd, data, size); }
+    @Override public int pipe(int[] fds) { return win._pipe(fds); }
+    @Override public String strerror(int error) { return win._strerror(error); }
+
+    @Override
+    public Runtime getRuntime() {
+        return Runtime.getRuntime(win);
+    }
+
+    // Unsupported Operations. Some may be implementable, others like fcntl may not be.
+
+    @Override
+    public int fcntl(int fd, int cmd, int data) {
+        throw new UnsupportedOperationException("fcntl isn't supported on Windows");
+    }
+
+    @Override
+    public int poll(ByteBuffer pfds, int nfds, int timeout) {
+        throw new UnsupportedOperationException("poll isn't supported on Windows");
+    }
+
+    @Override
+    public int poll(Pointer pfds, int nfds, int timeout) {
+        throw new UnsupportedOperationException("poll isn't supported on Windows");
+    }
+
+    @Override
+    public int kqueue() {
+        throw new UnsupportedOperationException("kqueue isn't supported on Windows");
+    }
+
+    @Override
+    public int kevent(int kq, ByteBuffer changebuf, int nchanges, ByteBuffer eventbuf, int nevents, Timespec timeout) {
+        throw new UnsupportedOperationException("kevent isn't supported on Windows");
+    }
+
+    @Override
+    public int kevent(int kq, Pointer changebuf, int nchanges, Pointer eventbuf, int nevents, Timespec timeout) {
+        throw new UnsupportedOperationException("kevent isn't supported on Windows");
+    }
+
+    @Override
+    public int shutdown(int s, int how) {
+        throw new UnsupportedOperationException("shutdown isn't supported on Windows");
+    }
+}


### PR DESCRIPTION
This adds partial windows support for LibC by mapping the msvcrt renamed _underscore names to standard libc names. Notably async IO is not supported as neither poll nor fcntl is implemented in msvcrt. Successfully tested simple blocking read/write with this code:

```rb
module WinC
    extend FFI::Library
    ffi_lib 'msvcrt'
    ffi_convention :stdcall
    attach_function :_open_osfhandle,     [:pointer, :int], :int, blocking: true
end
module Win32
    extend FFI::Library
    ffi_lib 'kernel32'
    ffi_convention :stdcall

    GENERIC_READ  = 0x80000000
    GENERIC_WRITE = 0x40000000
    OPEN_EXISTING = 3

    attach_function :CreateFileA,     [:pointer, :uint32, :uint32, :pointer, :uint32, :uint32, :pointer], :pointer, blocking: true
end

# Open Serial port using Win32 API
f = Win32.CreateFileA("COM4", ( Win32::GENERIC_READ | Win32::GENERIC_WRITE), 0, nil, Win32::OPEN_EXISTING,(0), nil) 
fd = WinC._open_osfhandle(f, File::RDWR ) # convert Win32 HANDLE to LibC int fd
s = IO.for_fd(fd,  File::RDWR ) # wrap in ruby IO object

s.write('i')
p s.read(1)
```
provided you also apply this patch to jruby:
```diff
diff --git a/core/src/main/java/org/jruby/RubyIO.java b/core/src/main/java/org/jruby/RubyIO.java
index fdb170c35e..14710bfe4f 100644
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -906,7 +906,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
                             fd = new ChannelFD(Channels.newChannel(runtime.getErr()), runtime.getPosix(), runtime.getFilenoUtil());
                             break;
                         default:
-                            throw runtime.newErrnoEBADFError("Windows does not support wrapping native file descriptor: " + fileno);
+                    fd = new ChannelFD(new NativeDeviceChannel(fileno), runtime.getPosix(), runtime.getFilenoUtil());
+                            break;//throw runtime.newErrnoEBADFError("Windows does not support wrapping native file descriptor: " + fileno);
                     }
                 } else {
                     fd = new ChannelFD(new NativeDeviceChannel(fileno), runtime.getPosix(), runtime.getFilenoUtil());

```