### PR TITLE
Load libsocket on Solaris

### DIFF
--- a/src/main/java/jnr/enxio/channels/Native.java
+++ b/src/main/java/jnr/enxio/channels/Native.java
@@ -68,8 +68,13 @@ public final class Native {
         static final jnr.ffi.Runtime runtime;
 
         static {
-            Platform platform =  Platform.getNativePlatform();
-            LibC straight = LibraryLoader.create(LibC.class).load(platform.getStandardCLibraryName());
+            Platform platform = Platform.getNativePlatform();
+            LibraryLoader<LibC> loader = LibraryLoader.create(LibC.class);
+            loader.library(platform.getStandardCLibraryName());
+            if (platform.getOS() == OS.SOLARIS) {
+                loader.library("socket");
+            }
+            LibC straight = loader.load();
             if (platform.getOS() == OS.WINDOWS)    {
                 LibMSVCRT mslib = LibraryLoader.create(LibMSVCRT.class).load(platform.getStandardCLibraryName());
                 libc = new WinLibCAdapter(mslib);


### PR DESCRIPTION
On SysV, socket-related calls (**shutdown(2)** in this case) are not available in `libc.so.1`, but in a separated socket library; such library must be loaded on that platform, or failure occurs:
```
java.lang.UnsatisfiedLinkError: unknown
        at jnr.ffi.provider.jffi.AsmRuntime.newUnsatisifiedLinkError(AsmRuntime.java:40)
        at jnr.enxio.channels.Native$LibC$jnr$ffi$1.shutdown(Unknown Source)
        at jnr.enxio.channels.Native.shutdown(Native.java:155)
        at jnr.unixsocket.impl.AbstractNativeServerSocketChannel.implCloseSelectableChannel(AbstractNativeServerSocketChannel.java:40)
        at java.nio.channels.spi.AbstractSelectableChannel.implCloseChannel(AbstractSelectableChannel.java:231)
        at java.nio.channels.spi.AbstractInterruptibleChannel.close(AbstractInterruptibleChannel.java:115)
...
```