### PR TITLE
The kqueue(2)-based Selector implementation has an out-of-bound writing of a structure member

### DIFF
--- a/src/main/java/jnr/enxio/channels/KQSelector.java
+++ b/src/main/java/jnr/enxio/channels/KQSelector.java
@@ -311,7 +311,7 @@ class KQSelector extends java.nio.channels.spi.AbstractSelector {
         public final void put(Pointer buf, int index, int fd, int filt, int flags) {
             buf.putInt(uintptr_t, (index * layout.size()) + layout.ident.offset(), fd);
             buf.putShort((index * layout.size()) + layout.filter.offset(), (short) filt);
-            buf.putInt((index * layout.size()) + layout.flags.offset(), flags);
+            buf.putShort((index * layout.size()) + layout.flags.offset(), (short)flags);
         }
         
         public final int size() {


### PR DESCRIPTION
When reading the code of kqueue(2)-based Selector implementation, in source file `jnr/enxio/channels/KQSelector.java`, I found an 4-byte write to an **uint16** (2-byte) structure member,specifically the `flags` field of `struct kevent`; this could cause part of the next field `fflags` being overwritten unintentionally.