### PR TITLE
Don't print diagnostic messages to stdout

### DIFF
--- a/src/main/java/jnr/enxio/channels/KQSelector.java
+++ b/src/main/java/jnr/enxio/channels/KQSelector.java
@@ -156,7 +156,7 @@ class KQSelector extends java.nio.channels.spi.AbstractSelector {
             ts = new Native.Timespec(sec, nsec);
         }
 
-        if (DEBUG) System.out.printf("nchanged=%d\n", nchanged);
+        if (DEBUG) System.err.printf("nchanged=%d\n", nchanged);
         int nready = 0;
         try {
             begin();
@@ -166,7 +166,7 @@ class KQSelector extends java.nio.channels.spi.AbstractSelector {
 
             } while (nready < 0 && Errno.EINTR.equals(Errno.valueOf(Native.getRuntime().getLastError())));
 
-            if (DEBUG) System.out.println("kevent returned " + nready + " events ready");
+            if (DEBUG) System.err.println("kevent returned " + nready + " events ready");
 
         } finally {
             end();
@@ -180,7 +180,7 @@ class KQSelector extends java.nio.channels.spi.AbstractSelector {
 
                 if (d != null) {
                     int filt = io.getFilter(eventbuf, i);
-                    if (DEBUG) System.out.printf("fd=%d filt=0x%x\n", d.fd, filt);
+                    if (DEBUG) System.err.printf("fd=%d filt=0x%x\n", d.fd, filt);
                     for (KQSelectionKey k : d.keys) {
                         int iops = k.interestOps();
                         int ops = 0;
@@ -199,7 +199,7 @@ class KQSelector extends java.nio.channels.spi.AbstractSelector {
                     }
 
                 } else if (fd == pipefd[0]) {
-                    if (DEBUG) System.out.println("Waking up");
+                    if (DEBUG) System.err.println("Waking up");
                     wakeupReceived();
                 }
             }
@@ -272,7 +272,7 @@ class KQSelector extends java.nio.channels.spi.AbstractSelector {
                         changed.write = false;
                     }
                 }
-                if (DEBUG) System.out.printf("Updating fd %d filt=0x%x flags=0x%x\n",
+                if (DEBUG) System.err.printf("Updating fd %d filt=0x%x flags=0x%x\n",
                     changed.fd, filt, flags);
                 if (flags != 0) {
                     io.put(changebuf, _nchanged++, changed.fd, filt, flags);


### PR DESCRIPTION
The stdin and stdout streams are often used to transfer machine-parsable data, sometimes even strictly formatted binary data such as raw integers or other complex structures; to avoid breaking such workflows, JNR ENXIO, as a library, should never write anything to stdout, even temporarily, unless being told to do so.

This change removed all diagnostic uses of `System.out`, replaced with `System.err`, the stderr stream instead.