### PR TITLE
Update jnr-ffi to 2.1.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.15</version>
+      <version>2.2.16</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Updates:

* Update jffi to 1.3.13 (https://github.com/jnr/jnr-ffi/pull/342).